### PR TITLE
Renamed GVarFunc -> GVarFuncTableHelper

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -3,7 +3,7 @@ SetPackageInfo( rec(
 PackageName := "NormalizInterface",
 Subtitle := "GAP wrapper for normaliz",
 Version := "0.2",
-Date    := "26/08/2014", # dd/mm/yyyy format
+Date    := "16/03/2015", # dd/mm/yyyy format
 
 Persons := [
   rec(

--- a/src/normaliz.cc
+++ b/src/normaliz.cc
@@ -765,12 +765,12 @@ Obj NmzCongruences(Obj self, Obj cone)
 }
 
 
-typedef Obj (* GVarFunc)(/*arguments*/);
+typedef Obj (* GVarFuncTableHelper)(/*arguments*/);
 
 #define GVAR_FUNC_TABLE_ENTRY(srcfile, name, nparam, params) \
   {#name, nparam, \
    params, \
-   (GVarFunc)name, \
+   (GVarFuncTableHelper)name, \
    srcfile ":Func" #name }
 
 // Table of functions to export


### PR DESCRIPTION
since GVarFunc is already bound in HPC-GAP.